### PR TITLE
include an entry for the last email in the mailbox

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,16 @@ impl<'a> Iterator for MboxReader<'a> {
             }
             self.idx += 1;
         }
-        None
+        if self.prev != self.idx {
+            let entry = Entry {
+                idx: self.idx,
+                bytes: &bytes[self.prev..self.idx],
+            };
+            self.prev = self.idx;
+            Some(entry)
+        } else {
+            None
+        }
     }
 }
 


### PR DESCRIPTION
in MboxReader, if it reaches the end of the loop without finding another
"From " sequence, don't return None, but return an entry for the
remaining bytes if there are any. The last email doesn't have a
following "From " sequence so otherwise it gets skipped.